### PR TITLE
Allow setting indoor/outdoor food separately

### DIFF
--- a/optimize.py
+++ b/optimize.py
@@ -473,55 +473,61 @@ def mutate_yard(yard: Yard) -> Yard:
     [outdoor_large, removed_outdoor_large] = pick(outdoor_large)
     [outdoor_small, removed_outdoor_small] = pick(outdoor_small)
 
-    indoor_large = set(indoor_large)
-    indoor_small = set(indoor_small)
-    outdoor_large = set(outdoor_large)
-    outdoor_small = set(outdoor_small)
-
     used_items = set(yard.used)
     for x in [removed_indoor_large, removed_indoor_small, removed_outdoor_large, removed_outdoor_small]:
         if x is not None:
             used_items.remove(x)
 
-    if removed_indoor_large is not None:
+    guaranteed_modified = randint(0, 3)
+    # Removed something and not mutate to -1 large item OR mutate to +1 large item
+    if removed_indoor_large is not None and not (random() < 0.1 and len(SMALL_ITEMS) > PLACES_INDOOR + PLACES_OUTDOOR) or (random() < 0.1 and len(LARGE_ITEMS) >= 2):
         while True:
             new_item = choice(LARGE_ITEMS)
-            if random() < 0.5:
+            if guaranteed_modified != 0 and random() < 0.7:
                 new_item = removed_indoor_large
             if new_item not in used_items:
                 break
-        indoor_large.add(new_item)
+            
+        indoor_large.append(new_item)
         used_items.add(new_item)
 
     if removed_indoor_small is not None:
-        while True:
-            new_item = choice(SMALL_ITEMS)
-            if random() < 0.5:
-                new_item = removed_indoor_small
-            if new_item not in used_items:
-                break
-        indoor_small.add(new_item)
-        used_items.add(new_item)
+        while len(indoor_small) + len(indoor_large) * 2 < PLACES_INDOOR:
+            while True:
+                new_item = choice(SMALL_ITEMS)
+                if guaranteed_modified != 1 and random() < 0.7:
+                    new_item = removed_indoor_small
+                if new_item not in used_items:
+                    break
+            indoor_small.append(new_item)
+            used_items.add(new_item)
+    while len(indoor_small) + len(indoor_large) * 2 > PLACES_INDOOR:
+        [indoor_small, removed] = pick(indoor_small)
+        used_items.remove(removed)
 
-    if removed_outdoor_large is not None:
+    if removed_outdoor_large is not None and not (random() < 0.1 and len(SMALL_ITEMS) > PLACES_INDOOR + PLACES_OUTDOOR) or (random() < 0.1 and len(LARGE_ITEMS) >= 2):
         while True:
             new_item = choice(LARGE_ITEMS)
-            if random() < 0.5:
+            if guaranteed_modified != 2 and random() < 0.7:
                 new_item = removed_outdoor_large
             if new_item not in used_items:
                 break
-        outdoor_large.add(new_item)
+        outdoor_large.append(new_item)
         used_items.add(new_item)
 
     if removed_outdoor_small is not None:
-        while True:
-            new_item = choice(SMALL_ITEMS)
-            if random() < 0.5:
-                new_item = removed_outdoor_small
-            if new_item not in used_items:
-                break
-        outdoor_small.add(new_item)
-        used_items.add(new_item)
+        while len(outdoor_small) + len(outdoor_large) * 2 < PLACES_OUTDOOR:
+            while True:
+                new_item = choice(SMALL_ITEMS)
+                if guaranteed_modified != 3 and random() < 0.7:
+                    new_item = removed_outdoor_small
+                if new_item not in used_items:
+                    break
+            outdoor_small.append(new_item)
+            used_items.add(new_item)
+    while len(outdoor_small) + len(outdoor_large) * 2 > PLACES_OUTDOOR:
+        [outdoor_small, removed] = pick(outdoor_small)
+        used_items.remove(removed)
 
     if random() < 0.7:
         food_type_indoor = yard.food_type_indoor
@@ -532,6 +538,11 @@ def mutate_yard(yard: Yard) -> Yard:
         food_type_outdoor = yard.food_type_outdoor
     else:
         food_type_outdoor = choice(ALLOWED_FOODS)
+
+    indoor_large = set(indoor_large)
+    indoor_small = set(indoor_small)
+    outdoor_large = set(outdoor_large)
+    outdoor_small = set(outdoor_small)
 
     return create_yard(food_type_indoor, indoor_large, indoor_small, food_type_outdoor, outdoor_large, outdoor_small)
 

--- a/optimize.py
+++ b/optimize.py
@@ -234,7 +234,7 @@ def main():
         print(analyze_command.strip())
 
 
-        
+
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from multiprocessing import cpu_count
 
@@ -296,7 +296,7 @@ def create_offspring_and_mutate(pool: set[Yard], winners: list[Yard]) -> list[Ya
         for result in offspring:
             if random() < MUTATION_OFFSPRING_RATE:
                 offspring.append(mutate_yard(result))
-            
+
         for yard in list(pool):
             if random() < MUTATION_RATE:
                 offspring.append(mutate_yard(yard))
@@ -353,7 +353,7 @@ def get_value(food_type_indoor: int, a: set[int], b: set[int], food_type_outdoor
     analyzer = NekoAtsumeAnalyzer(args)
     results = analyzer.analyze()
     if type is None:
-        max_food = 0 
+        max_food = 0
         # When maximizing for some expensive food while trying to minimize what could've been done cheaper
         # for x in range(1, 8):
         #     if x == args.food_type:
@@ -383,15 +383,15 @@ def k_tournament(yards: set[Yard]) -> set[Yard]:
 
 def crossover_mutation(left: Yard, right: Yard) -> list[Yard]:
     crossed = False
-    if len(left.indoor_large) == len(right.indoor_large): 
+    if len(left.indoor_large) == len(right.indoor_large):
         [a_indoor_large, b_indoor_large] = crossover(left.indoor_large, right.indoor_large, left.used, right.used)
         [a_indoor_small, b_indoor_small] = crossover(left.indoor_small, right.indoor_small, left.used, right.used)
         crossed = True
     else: # No crossover if different
         [a_indoor_large, b_indoor_large] = [left.indoor_large, right.indoor_large]
         [a_indoor_small, b_indoor_small] = [left.indoor_small, right.indoor_small]
-    
-    if len(left.outdoor_large) == len(right.outdoor_large): 
+
+    if len(left.outdoor_large) == len(right.outdoor_large):
         [a_outdoor_large, b_outdoor_large] = crossover(left.outdoor_large, right.outdoor_large, left.used, right.used)
         [a_outdoor_small, b_outdoor_small] = crossover(left.outdoor_small, right.outdoor_small, left.used, right.used)
         crossed = True
@@ -401,7 +401,7 @@ def crossover_mutation(left: Yard, right: Yard) -> list[Yard]:
 
     if not crossed:
         return []
-    
+
     if random() < 0.5:
         [a_food_indoor, b_food_indoor] = [right.food_type_indoor, left.food_type_indoor]
     else:
@@ -451,7 +451,7 @@ def crossover(left: set[int], right: set[int], left_used: set[int], right_used: 
 
     l = list(left)
     r = list(right)
-    
+
     for _ in range(randint(0, len(l) - 1)):
         swap_index = randint(0, len(l) - 1)
         tmp = l[swap_index]
@@ -522,13 +522,13 @@ def mutate_yard(yard: Yard) -> Yard:
                 break
         outdoor_small.add(new_item)
         used_items.add(new_item)
-    
-    if random() < 0.3:
+
+    if random() < 0.7:
         food_type_indoor = yard.food_type_indoor
     else:
         food_type_indoor = choice(ALLOWED_FOODS)
 
-    if random() < 0.3:
+    if random() < 0.7:
         food_type_outdoor = yard.food_type_outdoor
     else:
         food_type_outdoor = choice(ALLOWED_FOODS)


### PR DESCRIPTION
Also updates optimizer for it, can now mix food (also fixes small bug where previously penalty was per indoor/outdoor so it was half what it should be, now it's accounted for both sides individually so it's fine now)

```
Iteration #250 iteration took 0.35s total time so far 96.43s
Best yard {122} {152, 106, 120} {222} {178, 298, 306}
  Items [106, 120, 122, 152, 178, 222, 298, 306]
  Value:  78.4198419193431
  Indoor food: Ritzy Bitz (penalty: 18.67 )
  Indoor: ['Cardboard Cafe', 'Fluffy Bed (White)', 'Ping-Pong Ball', 'Luxury Treasure-box']
  Outdoor food: Frisky Bitz (penalty: 0.8 )
  Outdoor: ['Beach Umbrella', 'Burger Cushion', 'Cowboy Hat', 'Golden Fish Statue']
  Value for gold_equiv: 97.88650858600977
  Value for silver_equiv: 3053.4443262353843
  Value for gold: 73.63524412260423
  Value for silver: 1212.5632231702784
python analyze.py --output_type gold_equiv --food_type_indoor 3 --food_type_outdoor 2 --group_def custom --item_damage_state 2 --items_of_interest_indoors 122 152 106 120 --items_of_interest_outdoors 222 178 298 306
```