### PR TITLE
Bump `NekoAtsume2Data` to 1.19.0; update data

### DIFF
--- a/data_inferred/item_to_name.json
+++ b/data_inferred/item_to_name.json
@@ -224,5 +224,8 @@
     "315": "Kick Toy (Tsuchinoko)",
     "316": "Kinsai Mat",
     "317": "Kitty Balloon",
-    "318": "Koban Mat"
+    "318": "Koban Mat",
+    "319": "Bunny Bed",
+    "320": "Bunny Bed DX",
+    "321": "Eco Bag (Pastel)"
 }

--- a/data_inferred/item_to_size.json
+++ b/data_inferred/item_to_size.json
@@ -217,5 +217,8 @@
     "315": false,
     "316": false,
     "317": false,
-    "318": false
+    "318": false,
+    "319": false,
+    "320": false,
+    "321": false
 }

--- a/data_inferred/playspace_to_name.json
+++ b/data_inferred/playspace_to_name.json
@@ -307,5 +307,8 @@
     "3150": "Kick Toy (Tsuchinoko)",
     "3160": "Kinsai Mat",
     "3170": "Kitty Balloon",
-    "3180": "Koban Mat"
+    "3180": "Koban Mat",
+    "3190": "Bunny Bed",
+    "3200": "Bunny Bed DX",
+    "3210": "Eco Bag (Pastel)"
 }


### PR DESCRIPTION
1.20.0 is out (changelogs mentioned new goodies 👀 ), but `NekoAtsume2Data` is not up to date yet